### PR TITLE
Fix slider "qualité des soins"

### DIFF
--- a/frontend/components/viewer/common/EntityDisplayer.vue
+++ b/frontend/components/viewer/common/EntityDisplayer.vue
@@ -198,6 +198,7 @@ function refreshDiscreteScoreAverages() {
         .map(c => (c.data as Record<string, number>)[field.key] ?? 0)
         .reduce((acc, score) => acc + score, 0) / props.entity.comments.filter(c => (c.data as Record<string, number>)[field.key] != null).length,
     }))
+    .filter(f => !isNaN(f.average))
 }
 
 refreshDiscreteScoreAverages()


### PR DESCRIPTION
To be merged preferentially after #2 

Fixes #1 

Fix a bug that caused, in some conditions, entities without a score for a slider (= "discrete score" field) to be displayed as if they had the worst score.

Note: this has no impact on the formula used to compute the mean value of scores for the entities that do have scores. 