### PR TITLE
Passage dans l'url de paramètres latitude longitude zoom et entité

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,6 +14,9 @@ export default defineNuxtConfig({
   app: {
     head: {
       title: 'Safehaven',
+      meta: [
+        { name: 'robots', content: 'noindex' },
+      ],
     },
   },
   css: [

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -147,7 +147,7 @@ onMounted(async () => {
 
       // Ensure the right tags are displayed
       state.filteringTags.forEach((tag) => {
-        if (entity.tags.includes(tag.id) && tag.is_filter) tag.active = null
+        if (entity.tags.includes(tag.id)) tag.active = null
       })
     }
     

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -132,9 +132,10 @@ onMounted(async () => {
     // Custom entity provided, try to display it
     await displayEntityId(customStartEntityId)
     const entity = state.activeEntity?.entity
-    if (entity?.id == customStartEntityId && entity?.locations.length) {
+
+    if (entity?.id == customStartEntityId) {
       // The entity is loaded and its infos are displayed
-      // It has a location, tho it might be invisible on the map depending on the current family and filter settings
+      // It might be invisible on the map depending on the current family and filter settings so we might have to change them
 
       // Ensure the right family is selected
       state.activeFamily = state.families.find((family) => family.id == entity.family_id) || state.activeFamily
@@ -148,8 +149,11 @@ onMounted(async () => {
       state.filteringTags.forEach((tag) => {
         if (entity.tags.includes(tag.id) && tag.is_filter) tag.active = null
       })
-
-      // Finally go to the entity location optionally using the given zoom
+    }
+    
+    if (entity?.id == customStartEntityId && entity?.locations.length) {
+      // The entity is loaded, its infos are displayed and it has a location
+      // Go to the entity location optionally using the given zoom
       goToGpsCoordinates([entity.locations[0].long, entity.locations[0].lat], customStartZoom)
     }
     else if(customStartCenter) {

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -106,8 +106,8 @@ onMounted(async () => {
   if (route.query.lat && route.query.lon) {
     if (typeof route.query.lat == 'string' && typeof route.query.lon == 'string') {
       const lat = Number(route.query.lat), lon = Number(route.query.lon)
-      const isLat = ! Number.isNaN(lat) && lat >= -90 && lat <= 90
-      const isLon = ! Number.isNaN(lon) && lon >= -180 || lon <= 180
+      const isLat = !Number.isNaN(lat) && lat >= -90 && lat <= 90
+      const isLon = !Number.isNaN(lon) && lon >= -180 && lon <= 180
       if (isLat && isLon) customStartCenter = [lon, lat]
     }
   }
@@ -116,7 +116,7 @@ onMounted(async () => {
   if (route.query.zoom) {
     if (typeof route.query.zoom == 'string') {
       const zoom = parseInt(route.query.zoom, 10)
-      if (! Number.isNaN(zoom) && zoom >= 0 && zoom <= 19) customStartZoom = zoom
+      if (!Number.isNaN(zoom) && zoom >= 0 && zoom <= 19) customStartZoom = zoom
     }
   }
 
@@ -139,7 +139,7 @@ onMounted(async () => {
       // It might be invisible on the map depending on the current family and filter settings so we might have to change them
 
       // Ensure the right family is selected
-      state.activeFamily = state.families.find((family) => family.id == entity.family_id) || state.activeFamily
+      state.activeFamily = state.families.find(family => family.id == entity.family_id) || state.activeFamily
 
       // Ensure the right category is displayed
       state.filteringCategories.forEach((category) => {
@@ -151,19 +151,19 @@ onMounted(async () => {
         if (entity.tags.includes(tag.id)) tag.active = null
       })
     }
-    
+
     if (hasEntity && entity.locations.length) {
       // The entity is loaded, its infos are displayed and it has a location
       // Go to the entity location optionally using the given zoom
       goToGpsCoordinates([entity.locations[0].long, entity.locations[0].lat], customStartZoom)
     }
-    else if(customStartCenter) {
+    else if (customStartCenter) {
       // Either the entity isn't loaded or it doesn't have a location, fallback to the custom location (and optional zoom) provided
       goToGpsCoordinates(customStartCenter, customStartZoom)
     }
   }
 
-  else if(customStartCenter) {
+  else if (customStartCenter) {
     // Custom location provided, go to it, optionally using the given zoom
     goToGpsCoordinates(customStartCenter, customStartZoom)
   }
@@ -182,7 +182,7 @@ function fitContainer() {
   return {} // Return default/fallback styles if needed
 }
 
-function goToGpsCoordinates(coordinates: Coordinate, zoom=13) {
+function goToGpsCoordinates(coordinates: Coordinate, zoom = 13) {
   mapRef.value?.goToGpsCoordinates(coordinates, zoom)
 }
 
@@ -204,7 +204,7 @@ async function displayEntityId(entityId: string) {
   }
 }
 
-async function goToEntity(entity: ViewerSearchedCachedEntity, zoom=14) {
+async function goToEntity(entity: ViewerSearchedCachedEntity, zoom = 14) {
   try {
     await state.selectEntity(entity.entity_id)
   }

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -132,8 +132,9 @@ onMounted(async () => {
     // Custom entity provided, try to display it
     await displayEntityId(customStartEntityId)
     const entity = state.activeEntity?.entity
+    const hasEntity = entity?.id == customStartEntityId
 
-    if (entity?.id == customStartEntityId) {
+    if (hasEntity) {
       // The entity is loaded and its infos are displayed
       // It might be invisible on the map depending on the current family and filter settings so we might have to change them
 
@@ -151,7 +152,7 @@ onMounted(async () => {
       })
     }
     
-    if (entity?.id == customStartEntityId && entity?.locations.length) {
+    if (hasEntity && entity.locations.length) {
       // The entity is loaded, its infos are displayed and it has a location
       // Go to the entity location optionally using the given zoom
       goToGpsCoordinates([entity.locations[0].long, entity.locations[0].lat], customStartZoom)

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -100,6 +100,29 @@ catch {
   }
 }
 
+// Center to the given location using the given zoom level if provided in the url query
+onMounted(() => {
+  let customStartCenter: Coordinate | undefined = undefined
+  if (route.query.lat && route.query.lon) {
+    if (typeof route.query.lat == 'string' && typeof route.query.lon == 'string') {
+      const lat = Number(route.query.lat), lon = Number(route.query.lon)
+      const isLat = ! Number.isNaN(lat) && lat >= -90 && lat <= 90
+      const isLon = ! Number.isNaN(lon) && lon >= -180 || lon <= 180
+      if (isLat && isLon) customStartCenter = [lon, lat]
+    }
+  }
+
+  let customStartZoom: number | undefined = undefined
+  if (route.query.zoom) {
+    if (typeof route.query.zoom == 'string') {
+      const zoom = parseInt(route.query.zoom, 10)
+      if (! Number.isNaN(zoom) && zoom >= 0 && zoom <= 19) customStartZoom = zoom
+    }
+  }
+
+  if(customStartCenter) goToGpsCoordinates(customStartCenter, customStartZoom)
+})
+
 const mapRef = ref<typeof ViewerMap>()
 
 // Compute the dynamic positioning of the sidebar

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -133,11 +133,27 @@ onMounted(async () => {
     await displayEntityId(customStartEntityId)
     const entity = state.activeEntity?.entity
     if (entity?.id == customStartEntityId && entity?.locations.length) {
-      // The entity is displayed, go to its location optionally using the given zoom
+      // The entity is loaded and its infos are displayed
+      // It has a location, tho it might be invisible on the map depending on the current family and filter settings
+
+      // Ensure the right family is selected
+      state.activeFamily = state.families.find((family) => family.id == entity.family_id) || state.activeFamily
+
+      // Ensure the right category is displayed
+      state.filteringCategories.forEach((category) => {
+        if (category.id == entity.category_id) category.active = true
+      })
+
+      // Ensure the right tags are displayed
+      state.filteringTags.forEach((tag) => {
+        if (entity.tags.includes(tag.id) && tag.is_filter) tag.active = null
+      })
+
+      // Finally go to the entity location optionally using the given zoom
       goToGpsCoordinates([entity.locations[0].long, entity.locations[0].lat], customStartZoom)
     }
     else if(customStartCenter) {
-      // Either the entity isn't displayed or it doesn't have a location, fallback to the custom location (and optional zoom) provided
+      // Either the entity isn't loaded or it doesn't have a location, fallback to the custom location (and optional zoom) provided
       goToGpsCoordinates(customStartCenter, customStartZoom)
     }
   }

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -113,8 +113,8 @@ function fitContainer() {
   return {} // Return default/fallback styles if needed
 }
 
-function goToGpsCoordinates(coordinates: Coordinate) {
-  mapRef.value?.goToGpsCoordinates(coordinates, 13)
+function goToGpsCoordinates(coordinates: Coordinate, zoom=13) {
+  mapRef.value?.goToGpsCoordinates(coordinates, zoom)
 }
 
 async function refreshMap() {
@@ -135,7 +135,7 @@ async function displayEntityId(entityId: string) {
   }
 }
 
-async function goToEntity(entity: ViewerSearchedCachedEntity) {
+async function goToEntity(entity: ViewerSearchedCachedEntity, zoom=14) {
   try {
     await state.selectEntity(entity.entity_id)
   }
@@ -153,7 +153,7 @@ async function goToEntity(entity: ViewerSearchedCachedEntity) {
     mapRef.value?.goToWebMercatorCoordinates([
       location.x,
       location.y,
-    ], 14)
+    ], zoom)
   }
 }
 </script>

--- a/frontend/pages/search/[token].vue
+++ b/frontend/pages/search/[token].vue
@@ -274,7 +274,7 @@ onMounted(async () => {
 
       // Ensure the right tags are displayed
       state.filteringTags.forEach((tag) => {
-        if (entity.tags.includes(tag.id) && tag.is_filter) tag.active = null
+        if (entity.tags.includes(tag.id)) tag.active = null
       })
     }
   }

--- a/frontend/pages/search/[token].vue
+++ b/frontend/pages/search/[token].vue
@@ -266,7 +266,7 @@ onMounted(async () => {
       // Let's update the filter settings so the UI is consistent
 
       // Ensure the right family is selected
-      state.activeFamily = state.families.find((family) => family.id == entity.family_id) || state.activeFamily
+      state.activeFamily = state.families.find(family => family.id == entity.family_id) || state.activeFamily
 
       // Ensure the right category is displayed
       state.filteringCategories.forEach((category) => {

--- a/frontend/pages/search/[token].vue
+++ b/frontend/pages/search/[token].vue
@@ -258,6 +258,25 @@ onMounted(async () => {
   if (customStartEntityId) {
     // Custom entity provided, try to display it
     await displayEntityId(customStartEntityId)
+    const entity = state.activeEntity?.entity
+
+    if (entity?.id == customStartEntityId) {
+      // The entity is loaded and its infos are displayed
+      // Let's update the filter settings so the UI is consistent
+
+      // Ensure the right family is selected
+      state.activeFamily = state.families.find((family) => family.id == entity.family_id) || state.activeFamily
+
+      // Ensure the right category is displayed
+      state.filteringCategories.forEach((category) => {
+        if (category.id == entity.category_id) category.active = true
+      })
+
+      // Ensure the right tags are displayed
+      state.filteringTags.forEach((tag) => {
+        if (entity.tags.includes(tag.id) && tag.is_filter) tag.active = null
+      })
+    }
   }
 })
 

--- a/frontend/pages/search/[token].vue
+++ b/frontend/pages/search/[token].vue
@@ -259,8 +259,9 @@ onMounted(async () => {
     // Custom entity provided, try to display it
     await displayEntityId(customStartEntityId)
     const entity = state.activeEntity?.entity
+    const hasEntity = entity?.id == customStartEntityId
 
-    if (entity?.id == customStartEntityId) {
+    if (hasEntity) {
       // The entity is loaded and its infos are displayed
       // Let's update the filter settings so the UI is consistent
 

--- a/frontend/pages/search/[token].vue
+++ b/frontend/pages/search/[token].vue
@@ -245,6 +245,22 @@ catch {
   }
 }
 
+// Display the given entity if provided in the url query
+onMounted(async () => {
+  let customStartEntityId: string | undefined = undefined
+  if (route.query.ent) {
+    if (typeof route.query.ent == 'string') {
+      const entityId = route.query.ent
+      customStartEntityId = entityId
+    }
+  }
+
+  if (customStartEntityId) {
+    // Custom entity provided, try to display it
+    await displayEntityId(customStartEntityId)
+  }
+})
+
 const query = ref('')
 const currentPage = ref(1)
 const pageSize = ref(20)


### PR DESCRIPTION
En mode carte, cette PR permet de passer dans l'url des paramètres permettant de centrer la carte sur une localisation ou une entité :
- `/map/token?lat=12&lon=34&zoom=15` centrera sur la coordonnée indiquée avec le niveau de zoom indiqué
- `/map/token?ent=id_entite&zoom=15` ouvrira l'entité indiquée, en centrant dessus avec le niveau de zoom indiqué
-  `/map/token?ent=id_entite&lat=12&lon=34&zoom=15` ouvrira l'entité indiquée en centrant dessus avec le niveau indiqué, avec un fallback sur la coordonnée indiquée si l'entité n'est pas trouvée

En mode liste, cette PR permet de passer dans l'url des paramètres permettant de présélectionner une entité :
- `/search/token?ent=id_entite` ouvrira l'entité indiquée (si le token a la permission d'afficher les détails entité)

Cette PR désactive également l'indexation sur l'ensemble du site via une balise meta robots noindex.