### PR TITLE
Fix 10 : bouton suivant grisé lors de l'ajout d'entité médicale sur le front public

### DIFF
--- a/frontend/components/form/DynamicField.vue
+++ b/frontend/components/form/DynamicField.vue
@@ -239,8 +239,9 @@ const isValid = computed(() => {
 
 emit('isValid', isValid.value)
 
-function updateField(value: undefined | FieldContentMap[FormField['field_type']]) {
+async function updateField(value: undefined | FieldContentMap[FormField['field_type']]) {
   emit('update:fieldContent', value)
+  await nextTick()
   emit('isValid', isValid.value)
 }
 


### PR DESCRIPTION
Comme dans le titre, voir l'issue #10 .