### PR TITLE
Toujours afficher la popup de démarrage par dessus le drawer des infos entité

### DIFF
--- a/frontend/components/StartPopup.vue
+++ b/frontend/components/StartPopup.vue
@@ -9,6 +9,8 @@
     :draggable="false"
     :style="{ width: '50rem' }"
     :breakpoints="{ '1199px': '75vw', '575px': '90vw' }"
+    :auto-z-index="false"
+    :pt:mask:style="{ zIndex: 10000 }"
   >
     <div
       class="rich-text-content"


### PR DESCRIPTION
Fix #15 

Actuellement si on accède à la carte en passant un id_entite et sans avoir déjà validé la popup de démarrage, cette dernière s'affiche derrière le drawer des infos entité. Cette PR fixe le z-index de la popup de démarrage à une valeur supérieure à celle du drawer pour qu'elle s'affiche par dessus.

Pour tester : 
- Accéder à https://carte.fransgenre.fr/map/cec?ent=1dab5eea-727a-4fbf-857e-5cbe2e5b8778&lat=46.201858&lon=5.220548&zoom=13 en navigation privée avec une largeur d'écran autour de 1024px, noter le drawer par dessus la popup
- Tester en dev avec le fix (il faudra probablement mettre en id_entite de dev si on a pas les entités de prod), noter la popup par dessus le drawer