### PR TITLE
Emettre l'info de validité des champs dynamiques Boolean et EventList à leur initialisation de valeur par défaut

### DIFF
--- a/frontend/components/form/DynamicField.vue
+++ b/frontend/components/form/DynamicField.vue
@@ -248,10 +248,11 @@ async function updateField(value: undefined | FieldContentMap[FormField['field_t
 function initializeValue() {
   switch (props.formField.field_type) {
     case 'EventList':
-      emit('update:fieldContent', [{ date: undefined, type: undefined, details: undefined }])
+      updateField([{ date: undefined, type: undefined, details: undefined }])
       break
     case 'Boolean':
-      emit('update:fieldContent', false)
+      updateField(false)
+      break
   }
 }
 


### PR DESCRIPTION
Fix #12  

Actuellement l'état de validité de ces champs n'est pas émis lorsqu'ils sont initialisés à la valeur par défaut, il faut qu'ils soient re-rendered ou que l'on interagisse avec. S'ils sont marqués comme requis, alors le bouton Suivant sera grisé au départ. Avec ce PR l'état de validité est émis une fois l'initialisation à la valeur par défaut effectuée, ils seront considérés comme non-vides et valides dès le départ s'ils sont requis.

Tester : 
- En production tenter d'ajouter un commentaire de CEC ou une entité avec un commentaire de CEC cause un bouton Sauvegarder grisé la première fois, qui se dégrise si on fait Précédent Suivant sans rien toucher
- En dev avec ce fix le problème ne se pose plus

A noter que DynamicField.vue impacte le front public et le front admin (mais dans le cas de l'admin on ne fait pas de vérification de la validité actuellement).