### PR TITLE
Ne valider que les champs de la catégorie concernée pour l'ajout d'entité ou de commentaire

### DIFF
--- a/frontend/components/viewer/CommentAddForm.vue
+++ b/frontend/components/viewer/CommentAddForm.vue
@@ -178,7 +178,9 @@ function isCommentPageValid(page: number) {
   if (page === 0) {
     return isValidText(editedComment.value!.author) && isValidRichText(editedComment.value!.text)
   }
-  return commentFieldsSortedByPage(page).every(field => commentFieldValid.value[field.key])
+  return commentFieldsSortedByPage(page)
+    .filter(field => field.categories == null || field.categories.includes(editedComment.value!.entity_category_id))
+    .every(field => commentFieldValid.value[field.key])
 }
 
 function hCaptchaVerify(token: string) {

--- a/frontend/components/viewer/EntityAddForm.vue
+++ b/frontend/components/viewer/EntityAddForm.vue
@@ -282,14 +282,18 @@ function isEntityPageValid(page: number) {
   if (page === 0) {
     return isValidText(editedEntity.value.display_name) && isValidText(editedEntity.value.category_id)
   }
-  return entityFieldsSortedByPage(page).every(field => entityFieldValid.value[field.key])
+  return entityFieldsSortedByPage(page)
+    .filter(field => field.categories == null || field.categories.includes(editedEntity.value.category_id))
+    .every(field => entityFieldValid.value[field.key])
 }
 
 function isCommentPageValid(page: number) {
   if (page === 0) {
     return isValidText(editedComment.value.author) && isValidRichText(editedComment.value.text)
   }
-  return commentFieldsSortedByPage(page).every(field => commentFieldValid.value[field.key])
+  return commentFieldsSortedByPage(page)
+    .filter(field => field.categories == null || field.categories.includes(editedComment.value.entity_category_id))
+    .every(field => commentFieldValid.value[field.key])
 }
 
 function hCaptchaVerify(token: string) {


### PR DESCRIPTION
Fix #13 

Auparavant `isEntityPageValid(page)` et `isCommentPageValid(page)` validaient l'ensemble des champs à afficher sur la page de formulaire au numéro indiqué, sans tenir compte de si ces champs font bien partie de ceux à remplir pour la catégorie de l'entité.

Cette PR restreint la validation des champs à ces derniers, et règle le soucis du bouton de sauvegarde grisé pour l'ajout de commentaires sur des entités Divers.

Tester : 
- En prod, essayer d'ajouter une entité Divers avec un commentaire, constater que le bouton de Sauvegarde ne se dégrise jamais
- En dev avec le fixe, essayer d'ajouter une entité Divers avec un commentaire, tout va bien

Etant donné que `EntityAddForm` et `CommentAddForm` sont importants, je recommande de tester aussi pour les autres familles que Divers que cela marche toujours.