### PR TITLE
Fix issue 29 nombre de commentaires dans l'onglet

### DIFF
--- a/frontend/components/viewer/common/EntityDisplayer.vue
+++ b/frontend/components/viewer/common/EntityDisplayer.vue
@@ -21,7 +21,8 @@
           v-if="hasComments"
           value="3"
         >
-          Commentaires
+          Commentaire{{ props.entity.comments.length > 1 ? 's' : '' }}
+          ({{ props.entity.comments.length }})
         </Tab>
       </TabList>
 

--- a/frontend/pages/admin/[familyId]/entities/[id].vue
+++ b/frontend/pages/admin/[familyId]/entities/[id].vue
@@ -17,7 +17,13 @@
         <Tab
           value="2"
         >
-          Commentaires
+          <template v-if="!hasLoadedComments">
+            Commentaires
+          </template>
+          <template v-else>
+            Commentaire{{ entityComments.length > 1 ? 's' : '' }}
+            ({{ entityComments.length }})
+          </template>
         </Tab>
       </TabList>
 
@@ -191,8 +197,11 @@ const tags = state.tags
 
 const fetchedEntity = ref(await state.client.getEntity(entityId))
 const entityComments = ref<AdminComment[]>([])
+const hasLoadedComments = ref(false)
 async function refreshComments() {
+  hasLoadedComments.value = false
   entityComments.value = await state.client.listEntityComments(entityId)
+  hasLoadedComments.value = true
 }
 refreshComments()
 


### PR DESCRIPTION
Fix #29 : 
- trouver une entité avec 2 commentaires ou plus en prod, les onglets commentaires en front public et admin disent "Commentaires"
- faire de même en dev, les onglets commentaires disent "Commentaires (2)"
- trouver une entité avec 1 commentaire en prod, les onglets commentaires en front public et admin disent "Commentaires"
- faire de même en dev, les onglets commentaires disent "Commentaire (1)"
- trouver une entité avec 0 commentaire en prod, l'onglet commentaires en front admin dit "Commentaires"
- faire de même en dev, l'onglet commentaires dit "Commentaire (0)"
- pour info, le nombre affiché dans l'onglet en admin est aussi mis à jour en cas de suppression