### PR TITLE
Normalisation des listes d’événements

### DIFF
--- a/backend/migrations/20250904102109_normalize_lists_of_events.sql
+++ b/backend/migrations/20250904102109_normalize_lists_of_events.sql
@@ -1,0 +1,48 @@
+-- Usage de `[]` plutôt que `null` pour représenter l’absence d’événement.
+update comments
+set data = jsonb_set(data, '{list_of_events}', '[]'::jsonb)
+where data->'list_of_events' = 'null'::jsonb;
+
+-- Suppression des évènements vides et nulls dans les commentaires.
+update comments
+-- Mise à jour de la liste des événements de ce commentaire.
+set data = jsonb_set(
+  data,
+  '{list_of_events}',
+  (
+    -- Reconstruction de la liste des événements de ce commentaire.
+    select coalesce( jsonb_agg(event), '[]'::jsonb )
+    -- Pour tous les événements non-vides et non-nulls de ce commentaire.
+    from jsonb_array_elements(data->'list_of_events') events(event)
+    where event != '{}'::jsonb
+    and event != 'null'::jsonb
+  )
+)
+-- Pour tous les commentaires qui contiennent des événements.
+where jsonb_array_length(data->'list_of_events') > 0;
+
+-- Renommage du champ `comment` que certains événements ont en `details`.
+update comments
+-- Mise à jour de la liste des événements de ce commentaire.
+set data = jsonb_set(
+  data,
+  '{list_of_events}',
+  (
+    -- Reconstruction de la liste des événements de ce commentaire.
+    select jsonb_agg(
+      -- Définition du champ `details` pour cet événement.
+      jsonb_set(
+        event,
+        '{details}',
+        -- On retient le premier qui existe entre `comment` et `details`.
+        coalesce(event->'comment', event->'details')
+      )
+      -- Suppression du champ `comment` pour cet événement.
+      #- '{comment}'
+    )
+    -- Pour tous les événements de ce commentaire.
+    from jsonb_array_elements(data->'list_of_events') events(event)
+  )
+)
+-- Pour tous les commentaires qui contiennent des événements.
+where jsonb_array_length(data->'list_of_events') > 0;

--- a/flake.nix
+++ b/flake.nix
@@ -251,7 +251,7 @@
               # Process composing
               process-compose
               # PostgreSQL and PostGIS
-              (postgresql_16.withPackages (p: with p; [postgis]))
+              (postgresql_16.withPackages (p: with p; [postgis])).out
             ];
             DATABASE_URL = "postgres://postgres:postgres@localhost:5432/safehaven";
           };


### PR DESCRIPTION
## Introduction

Ce patch ajoute une migration à la base de données afin de normaliser les listes d’événements que les commentaires peuvent avoir.

1. `[]` est utilisé plutôt que `null` (celui de JSON, pas de SQL) pour représenter l’absence d’événement
2. les événements vide `{}` et `null` sont supprimés (merci @hellochloe1989)
3. le champ `comment` que certains événements ont est renommé en `details`, que d’autres ont aussi

Ce qui va permettre de fusionner #27 ! :tada: 

Au passage j’ai ajouté un correctif à la flake pour qu’on puisse utiliser `psql`. Je comprends pas tout à fait le problème et le correctif pour être honnête, mais ça fonctionne. :sweat_smile:

## Guide pour tester

> [!NOTE]
> J’ai appliqué la migration sur un dump de la base de données de production, et c’est passé.

L’idée est d’ajouter dans la base de données des commentaires pour les différents cas.

Une façon de faire ça est d’utiliser `psql` et de choisir un identifiant d’entité, par exemple ainsi :

```bash
psql -h localhost -U postgres safehaven
```

Puis :

```sql
select id from entities limit 1;
```

Ensuite, on peut ajouter des commentaires judicieusement choisis à cette entité :

```sql
-- Absence d’événement représentée par un `null` JSON.
insert into comments (entity_id, author, text, data) values ('<ID ENTITÉ>', 'Anonyme', 'Je suis un super commentaire.', '{"was_adult": true, "list_of_events": null, "type_of_request": "0", "provided_documents": [], "private_contact_mean": null, "name_was_already_changed": false}');
-- Liste avec seulement un événement vide.
insert into comments (entity_id, author, text, data) values ('<ID ENTITÉ>', 'Anonyme', 'Je suis un super commentaire.', '{"was_adult": true, "list_of_events": [{}], "type_of_request": "0", "provided_documents": [], "private_contact_mean": null, "name_was_already_changed": false}');
-- Liste avec un événement vide et un pas vide.
insert into comments (entity_id, author, text, data) values ('<ID ENTITÉ>', 'Anonyme', 'Je suis un super commentaire.', '{"was_adult": true, "list_of_events": [{"date": "2025-09-05T00:00:00+00:00", "type": "12", "details": "Des vrais détails."}, {}], "type_of_request": "0", "provided_documents": [], "private_contact_mean": null, "name_was_already_changed": false}');
-- Événement avec un champ `details`.
insert into comments (entity_id, author, text, data) values ('<ID ENTITÉ>', 'Anonyme', 'Je suis un super commentaire.', '{"was_adult": true, "list_of_events": [{"date": "2025-09-05T00:00:00+00:00", "type": "12", "details": "Des vrais détails."}], "type_of_request": "0", "provided_documents": [], "private_contact_mean": null, "name_was_already_changed": false}');
-- Événement avec un champ `comment`.
insert into comments (entity_id, author, text, data) values ('<ID ENTITÉ>', 'Anonyme', 'Je suis un super commentaire.', '{"was_adult": true, "list_of_events": [{"date": "2025-09-05T00:00:00+00:00", "type": "12", "comment": "Des vrais détails."}], "type_of_request": "0", "provided_documents": [], "private_contact_mean": null, "name_was_already_changed": false}');
```

On peut alors appliquer les migrations :

```bash
cd backend
sqlx migrate run
```

Puis vérifier que les commentaires qu’on a ajouté ont bien été normalisés :

```sql
select id, data from comments where entity_id = '<ID ENTITÉ>';
```