### PR TITLE
Désactivation de l'indentation par tabulation dans l'éditeur riche

### DIFF
--- a/frontend/plugins/sh-fix-quill-bindings.ts
+++ b/frontend/plugins/sh-fix-quill-bindings.ts
@@ -1,0 +1,43 @@
+import Keyboard from 'quill/modules/keyboard'
+import { defineNuxtPlugin } from '#app'
+
+const KEYCODE_TAB = 9
+const KEYNAME_TAB = 'Tab'
+
+/**
+ * This custom plugin fixes various key bindings used by the RichTextEditor of the Quill library, used internally by PrimeVue
+ */
+export default defineNuxtPlugin(() => {
+  // Prevent the RichTextEditor from blocking Tab navigation for indentation
+  // (see https://github.com/Fransgenre/carte/issues/7)
+  removeTabBindings()
+})
+
+function removeTabBindings() {
+  Object.keys(
+    Keyboard.DEFAULTS.bindings,
+  ).reduce(
+    (acc: string[], name: string) => {
+      const binding = Keyboard.DEFAULTS.bindings[name]
+
+      let isTab = false
+      if (KEYNAME_TAB == binding) isTab = true
+      else if (KEYCODE_TAB == binding) isTab = true
+      else if ('object' == typeof binding) {
+        const key = binding.key
+        if (KEYNAME_TAB == key) isTab = true
+        else if (KEYCODE_TAB == key) isTab = true
+        else if (Array.isArray(key)) {
+          isTab = key.some(value => KEYNAME_TAB == value)
+        }
+      }
+
+      if (isTab) acc.push(name)
+      return acc
+    },
+    [],
+  ).forEach((name) => {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete Keyboard.DEFAULTS.bindings[name]
+  })
+}


### PR DESCRIPTION
Cette PR supprime les bindings par défaut associés à la touche Tab dans l'éditeur de texte riche.  
Ces bindings sont notamment utilisés pour indenter, mais empêchent de passer aux champs suivants lorsque l'on appuie sur la touche Tab.

Pour tester :
- Constater que sans cette PR appuyer sur Tab dans un éditeur texte riche (par exemple dans l'ajout de commentaire) ajoute une indentation dans l'éditeur, et empêche de passer au champ suivant
- Constater qu'avec cette PR appuyer sur Tab dans un éditeur texte riche n'ajoute pas d'indentation mais fait passer au champ suivant

Limitations :
- On perd la possibilité d'indenter avec des tabulations dans les champs texte riche. A ma connaissance ce n'est pas une fonctionnalité utilisée actuellement (et vu la largeur de l'afficheur sur le front public, de grandes indentations seraient peu esthétiques).

Related #7 