### PR TITLE
Suppression de la vérification des nouvelles versions

### DIFF
--- a/backend/src/api/root.rs
+++ b/backend/src/api/root.rs
@@ -21,7 +21,6 @@ use uuid::Uuid;
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/status", get(status))
-        .route("/version", get(version))
         .route("/bootstrap/:token", get(bootstrap))
 }
 
@@ -121,36 +120,6 @@ pub struct BootstrapQueryParams {
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default)]
     pub referrer: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, ToSchema)]
-pub struct SafeHavenVersionResponse {
-    version: &'static str,
-    git_hash: &'static str,
-    github_latest_version: Option<String>,
-}
-
-async fn get_github_last_version() -> Option<String> {
-    let client = reqwest::Client::new();
-    let response = client
-        .get("https://api.github.com/repos/SafeHavenMaps/safehaven/releases/latest")
-        .header("User-Agent", "SafeHaven")
-        .send()
-        .await
-        .ok()?;
-    let json: serde_json::Value = response.json().await.ok()?;
-    let version = json.get("tag_name")?.as_str()?;
-    Some(version.to_string())
-}
-
-#[utoipa::path(get, path = "/api/version")]
-pub async fn version() -> AppJson<SafeHavenVersionResponse> {
-    let github_latest_version = get_github_last_version().await;
-    AppJson(SafeHavenVersionResponse {
-        version: env!("SH_VERSION"),
-        git_hash: env!("SH_GITHASH"),
-        github_latest_version,
-    })
 }
 
 #[utoipa::path(

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -9,10 +9,7 @@ use crate::{
             self, FetchEntityRequest, FetchedEntity, NewCommentRequest, PublicNewEntityRequest,
             PublicNewEntityResponse, SearchRequest as MapSearchRequest, ViewRequest,
         },
-        root::{
-            self, BootstrapPermissions, BootstrapResponse, SafeHavenVersionResponse, SafeMode,
-            StatusResponse,
-        },
+        root::{self, BootstrapPermissions, BootstrapResponse, SafeMode, StatusResponse},
         ErrorResponse,
     },
     helpers::postgis_polygons::MultiPolygon,
@@ -52,7 +49,6 @@ use utoipa::OpenApi;
     paths(
         root::status,
         root::bootstrap,
-        root::version,
         // map
         map::viewer_view_request,
         map::viewer_search_request,
@@ -135,7 +131,6 @@ use utoipa::OpenApi;
         SafeMode,
         BootstrapResponse,
         BootstrapPermissions,
-        SafeHavenVersionResponse,
         // options
         SafeHavenOptions,
         ConfigurationOption,

--- a/frontend/components/admin/Navbar.vue
+++ b/frontend/components/admin/Navbar.vue
@@ -57,38 +57,6 @@
         </template>
       </Button>
 
-      <template v-if="isUpdateAvailable">
-        <OverlayBadge
-          value="1"
-          severity="danger"
-        >
-          <Button
-            severity="secondary"
-            outlined
-            class="ml-2"
-            style="color: white; border-color: white;"
-            @click="toggleVersionPopup()"
-          >
-            <template #icon>
-              <AppIcon icon-name="information" />
-            </template>
-          </Button>
-        </OverlayBadge>
-      </template>
-      <template v-else>
-        <Button
-          severity="secondary"
-          outlined
-          class="ml-2"
-          style="color: white; border-color: white;"
-          @click="toggleVersionPopup()"
-        >
-          <template #icon>
-            <AppIcon icon-name="information" />
-          </template>
-        </Button>
-      </template>
-
       <Button
         rounded
         severity="secondary"
@@ -113,34 +81,6 @@
       />
     </template>
   </Toolbar>
-
-  <Dialog
-    v-model:visible="versionModalVisible"
-    header="Information de version"
-    modal
-    dismissable-mask
-  >
-    <Message
-      v-if="isUpdateAvailable"
-      severity="warn"
-      class="m-1"
-    >
-      Une mise à jour est disponible.<br>
-      <a href="https://github.com/SafeHavenMaps/safehaven/releases">Rendez-vous sur GitHub</a> pour voir et mettre à jour vers la dernière version.
-    </Message>
-    <div class="m-1">
-      Version actuelle: <pre>{{ state.versionInformation?.version ?? 'Inconnu' }}</pre>
-    </div>
-    <div class="m-1">
-      Git hash: <pre>{{ state.versionInformation?.git_hash ?? 'Inconnu' }}</pre>
-    </div>
-    <div
-      v-if="state.versionInformation?.github_latest_version"
-      class="m-1"
-    >
-      Dernière version: <pre>{{ state.versionInformation?.github_latest_version }}</pre>
-    </div>
-  </Dialog>
 </template>
 
 <script setup lang="ts">
@@ -151,22 +91,15 @@ const emit = defineEmits(['toggleSidebar'])
 const darkMode = useDarkMode()
 
 const accountMenu = useTemplateRef('accountMenu')
-const versionModalVisible = ref(false)
 const navbarRef: Ref<HTMLElement | null> = ref(null)
 
 try {
   await state.check_login()
   await state.fetchConfig()
-  await state.fetchVersionInformaton()
 }
 catch {
   // Do nothing
 }
-
-const isUpdateAvailable = computed(() => {
-  return state.versionInformation?.version !== 'main'
-    && state.versionInformation?.github_latest_version !== state.versionInformation?.version
-})
 
 const items = [
   {
@@ -194,10 +127,6 @@ function toggleAccountMenu(event: Event) {
 
 function toggleDarkMode() {
   darkMode.toggle()
-}
-
-function toggleVersionPopup() {
-  versionModalVisible.value = !versionModalVisible.value
 }
 </script>
 

--- a/frontend/lib.d.ts
+++ b/frontend/lib.d.ts
@@ -10,7 +10,6 @@ export type AppError = {
 }
 
 export type InitConfig = api.components['schemas']['StatusResponse']
-export type SafeHavenVersion = api.components['schemas']['SafeHavenVersionResponse']
 
 export type SafeHavenOptions = api.components['schemas']['SafeHavenOptions']
 export type ConfigurationOption = api.components['schemas']['ConfigurationOption']

--- a/frontend/lib/admin-client.ts
+++ b/frontend/lib/admin-client.ts
@@ -21,7 +21,6 @@ import type {
   AdminSearchRequestBody,
   AccessTokenStats,
   AdminEntityWithRelations,
-  SafeHavenVersion,
   Family,
   AdminPaginatedCachedEntities,
   AccessToken,
@@ -87,12 +86,6 @@ export default function useClient() {
     // Options
     async getConfig(): Promise<SafeHavenOptions> {
       const { data, error } = await this.rawClient.GET('/api/admin/options')
-      if (error) throw error
-      return data
-    },
-
-    async getVersionInformation(): Promise<SafeHavenVersion> {
-      const { data, error } = await this.rawClient.GET('/api/version')
       if (error) throw error
       return data
     },

--- a/frontend/lib/admin-state.ts
+++ b/frontend/lib/admin-state.ts
@@ -15,7 +15,6 @@ import type {
   FamilyRecord,
   TagRecord,
   EnumFilter,
-  SafeHavenVersion,
 } from '~/lib'
 
 interface Identifiable {
@@ -25,7 +24,6 @@ export class AppState {
   public client = useClient()
   // For categories, users, tags, access tokens, entities and comments the admin client shall be used directly
 
-  public versionInformation: SafeHavenVersion | null = null
   private optionsData: SafeHavenOptions | null = null
   private familiesData: Family[] | null = null
   public familyRecord: FamilyRecord = {}
@@ -83,10 +81,6 @@ export class AppState {
   // Config
   async fetchConfig(): Promise<void> {
     this.optionsData = await this.client.getConfig()
-  }
-
-  async fetchVersionInformaton(): Promise<void> {
-    this.versionInformation = await this.client.getVersionInformation()
   }
 
   get options(): SafeHavenOptions {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2693,15 +2693,6 @@
           }
         }
       }
-    },
-    "/api/version": {
-      "get": {
-        "tags": [
-          "root"
-        ],
-        "operationId": "version",
-        "responses": {}
-      }
     }
   },
   "components": {
@@ -4489,25 +4480,6 @@
           },
           "safe_mode": {
             "$ref": "#/components/schemas/SafeModeConfig"
-          }
-        }
-      },
-      "SafeHavenVersionResponse": {
-        "type": "object",
-        "required": [
-          "version",
-          "git_hash"
-        ],
-        "properties": {
-          "git_hash": {
-            "type": "string"
-          },
-          "github_latest_version": {
-            "type": "string",
-            "nullable": true
-          },
-          "version": {
-            "type": "string"
           }
         }
       },


### PR DESCRIPTION
On en a pas vraiment l’utilité, et ça fait des requêtes à GitHub et ça affiche actuellement une notification parce que la vérification est un `!=` et pas un `<` (ce qui impliquerait de parser le numéro de version).

J’ai complètement supprimé le modal admin d’information de version du coup.

Pour tester, on peut constater que sur la branche `main` il y a un bouton en haut à droite de la barre de navigation du panel admin qui permet d’ouvrir un modal avec les informations de versions, alors que avec ce patch il n’y a plus de bouton du tout.