### PR TITLE
Correction de la migration de normalisation des listes d’événements

### DIFF
--- a/backend/migrations/20250904102109_normalize_lists_of_events.sql
+++ b/backend/migrations/20250904102109_normalize_lists_of_events.sql
@@ -31,11 +31,13 @@ set data = jsonb_set(
     -- Reconstruction de la liste des événements de ce commentaire.
     select jsonb_agg(
       -- Définition du champ `details` pour cet événement.
-      jsonb_set(
+      jsonb_set_lax(
         event,
         '{details}',
         -- On retient le premier qui existe entre `comment` et `details`.
-        coalesce(event->'comment', event->'details', 'null'::jsonb)
+        coalesce(event->'comment', event->'details'),
+        true,
+        'return_target'
       )
       -- Suppression du champ `comment` pour cet événement.
       #- '{comment}'


### PR DESCRIPTION
Les événements sans `comment` ni `details` étaient transformés en `null`, ce qui cassait ensuite l’affichage de l’entité côté carte.