### PR TITLE
Fix issue 60 valeurs numériques pour secteur 3 et délai très long

### DIFF
--- a/backend/migrations/20251106131005_fix_sector_and_waiting_time_keys.sql
+++ b/backend/migrations/20251106131005_fix_sector_and_waiting_time_keys.sql
@@ -1,0 +1,67 @@
+-- Convertir en chaine les valeurs de secteur des entités médicales sauvegardées si elles sont au format nombre
+
+UPDATE entities
+SET data = jsonb_set(data, '{sector}', to_jsonb(data->>'sector'))
+WHERE jsonb_typeof(data->'sector') = 'number'
+AND category_id IN (
+  SELECT id
+  FROM categories
+  WHERE family_id = '7d7672cc-2261-4559-86de-645d6d1f85c0'
+);
+
+-- Convertir en chaine les valeurs de délai d'attente des entités médicales sauvegardées si elles sont au format nombre
+
+UPDATE entities
+SET data = jsonb_set(data, '{waiting_time_for_first_appointment}', to_jsonb(data->>'waiting_time_for_first_appointment'))
+WHERE jsonb_typeof(data->'waiting_time_for_first_appointment') = 'number'
+AND category_id IN (
+  SELECT id
+  FROM categories
+  WHERE family_id = '7d7672cc-2261-4559-86de-645d6d1f85c0'
+);
+
+-- Convertir en chaine les valeurs de secteur du réglage de famille médical si elles sont au format nombre
+
+UPDATE families
+SET entity_form = jsonb_set(entity_form, '{fields}', (
+  SELECT jsonb_agg(
+    CASE field->'key'
+      WHEN to_jsonb('sector'::text) THEN jsonb_set(field, '{field_type_metadata,options}', (
+        SELECT jsonb_agg(
+          CASE jsonb_typeof(opt->'value')
+            WHEN 'number' THEN jsonb_set(opt, '{value}', to_jsonb(opt->>'value'))
+            ELSE opt
+          END
+        )
+        FROM jsonb_array_elements(field->'field_type_metadata'->'options') opts(opt)
+      ))
+      ELSE field
+    END
+  )
+  FROM jsonb_array_elements(entity_form->'fields') fields(field)
+))
+WHERE entity_form @? '$.fields[*] ? (@.key == "sector").field_type_metadata.options[*] ? (@.value.type() == "number")'
+AND id = '7d7672cc-2261-4559-86de-645d6d1f85c0';
+
+-- Convertir en chaine les valeurs de délai d'attente du réglage de famille médical si elles sont au format nombre
+
+UPDATE families
+SET entity_form = jsonb_set(entity_form, '{fields}', (
+  SELECT jsonb_agg(
+    CASE field->'key'
+      WHEN to_jsonb('waiting_time_for_first_appointment'::text) THEN jsonb_set(field, '{field_type_metadata,options}', (
+        SELECT jsonb_agg(
+          CASE jsonb_typeof(opt->'value')
+            WHEN 'number' THEN jsonb_set(opt, '{value}', to_jsonb(opt->>'value'))
+            ELSE opt
+          END
+        )
+        FROM jsonb_array_elements(field->'field_type_metadata'->'options') opts(opt)
+      ))
+      ELSE field
+    END
+  )
+  FROM jsonb_array_elements(entity_form->'fields') fields(field)
+))
+WHERE entity_form @? '$.fields[*] ? (@.key == "waiting_time_for_first_appointment").field_type_metadata.options[*] ? (@.value.type() == "number")'
+AND id = '7d7672cc-2261-4559-86de-645d6d1f85c0';


### PR DESCRIPTION
Cette migration effectue en base les modifications suivantes :

Table entities
- Conversion de `data.sector` et `data.waiting_time_for_first_appointment` en chaines de caractères lorsqu'il s'agit de nombres, pour les entités de la famille médicale

Table families
- Conversion de `entity_form.fields[*].field_type_metadata.options[*].value` en chaines de caractères lorsqu'il s'agit de nombres, pour les fields avec `key="sector"` et `key="waiting_time_for_first_appointment"`, de la famille médicale

Pour tester il faut partir du dump de prod disponible dans le channel, il contient à l'heure actuelle les erreurs dans la configuration des familles, et il est impossible de créer/modifier des entités médicales avec un délai de rendez-vous très long ou un secteur 3.  
Avec ce patch ca devient possible.
Bien vérifier également que la fonction de recherche renvoie bien les entités en secteur 3 ou à délai très long.

Fix #60 