### PR TITLE
feat: Ajout d'un bouton de redirection vers l'entité rattachée à un ccommentaire

### DIFF
--- a/frontend/components/AppIcon.vue
+++ b/frontend/components/AppIcon.vue
@@ -79,6 +79,7 @@ const iconDict: Record<string, string> = {
   searchPage: mdi.mdiListBox,
   dice: mdi.mdiDiceMultiple,
   copy: mdi.mdiContentCopy,
+  externalLink: mdi.mdiOpenInNew,
 }
 </script>
 

--- a/frontend/pages/admin/[familyId]/comments/[id].vue
+++ b/frontend/pages/admin/[familyId]/comments/[id].vue
@@ -53,17 +53,22 @@
         outlined
         @click="entitySelectVisible=true"
       />
-      <NuxtLink
+      <Button
         v-if="urlEntityId || fetchedComment?.entity_id"
-        :to="entityLink"
-        target="_blank"
+        v-slot="slotProps"
+        as-child
+        outlined
+        class="w-full"
       >
-        <Button
-          label="Aller à l'entité de rattachement"
-          outlined
-          class="w-full"
-        />
-      </NuxtLink>
+        <NuxtLink
+          :to="entityLink"
+          :class="[slotProps.class, 'p-button-label']"
+          target="_blank"
+        >
+          <AppIcon icon-name="externalLink" />
+          Aller à l'entité de rattachement
+        </NuxtLink>
+      </Button>
       <AdminInputEntitySelect
         v-model:visible="entitySelectVisible"
         title="Choix de l'entité de rattachement du commentaire"
@@ -127,7 +132,7 @@ const isNew = (commentId === 'new')
 
 const urlEntityId = useRoute().query.urlEntityId
 
-const entityLink = computed(() => `/admin/${familyId}/entities/${fetchedComment?.entity_id ?? urlEntityId}`)
+const entityLink = computed(() => `/admin/${familyId}/entities/${editedComment.value.entity_id}`)
 const returnUrl = computed(() => urlEntityId == null ? `/admin/${familyId}/comments/pending` : `${entityLink.value}?comments`)
 
 const fetchedComment: AdminComment | null = isNew ? null : await state.client.getComment(commentId)


### PR DESCRIPTION
Resolves #69.

Le bouton ne s'affiche que quand on peut trouver une entité de rattachement. J'ai voulu tenter d'améliorer la réactivité en transformant un maximum de variable en computed, mais malheureusement ca m'aurait fait changer beaucoup trop de choses et ca devenait un peu trop complexe, je m'en suis tenu au minimum.

Je m'y connais assez peu en accessibilité, je savais pas si je devais faire un truc en plus pour ça, hésitez pas à m'indiquer ça.

Ah, et c'est ma première PR en open source donc pareil, dites moi s'il manque quelque chose !