### PR TITLE
Fix issue 81 recentrage SingleEntityMap en cas de changement de coordonnées

### DIFF
--- a/frontend/components/SingleEntityMap.vue
+++ b/frontend/components/SingleEntityMap.vue
@@ -40,10 +40,23 @@
 import type Map from 'ol/Map'
 import type { Coordinate } from 'ol/coordinate'
 
+const props = defineProps<{
+  coordinates: Coordinate[]
+  borderColor?: string | undefined
+  fillColor?: string | undefined
+  iconHash?: string | null | undefined
+  zoom: number
+  locked: boolean
+}>()
+
 const mapRef = ref<{ map: Map }>()
-let map: Map | null = null
-onMounted(() => {
-  map = mapRef.value!.map
+
+onMounted(centerViewOnCoordinates)
+watch(() => props.coordinates, centerViewOnCoordinates)
+
+function centerViewOnCoordinates() {
+  const map = mapRef.value?.map
+  if (!map) return
   const view = map.getView()
 
   if (props.coordinates.length === 1) {
@@ -71,16 +84,7 @@ onMounted(() => {
 
     view.fit(extent)
   }
-})
-
-const props = defineProps<{
-  coordinates: Coordinate[]
-  borderColor?: string | undefined
-  fillColor?: string | undefined
-  iconHash?: string | null | undefined
-  zoom: number
-  locked: boolean
-}>()
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
Cette PR corrige le bug de la `SingleEntityMap` qui ne se recentre pas quand ses coordonnées sont modifiées programmatiquement après son rendu initial.

C'est notamment visible quand on ajoute une adresse à une entité (soit via le viewer soit via l'admin) :

Avant la PR :
- si on cherche "Dijon", ca positionne un marqueur et ca centre dessus, puis si on cherche "Paris", ca positionne le marqueur mais ca ne centre pas dessus

Après la PR :
- si on cherche "Dijon", ca positionne un marqueur et ca centre dessus, puis si on cherche "Paris", ca positionne le marqueur et ca centre bien dessus

Fix #81 