### PR TITLE
Feature 95 zoom dynamique selon le lieu recherché

### DIFF
--- a/frontend/components/viewer/Navbar.vue
+++ b/frontend/components/viewer/Navbar.vue
@@ -392,6 +392,7 @@
 
 <script setup lang="ts">
 import type { Coordinate } from 'ol/coordinate'
+import type { Extent } from 'ol/extent'
 import type { PageState } from 'primevue/paginator'
 import state from '~/lib/viewer-state'
 import defaultLogo from '~/assets/logo_square.svg'
@@ -422,7 +423,7 @@ const entityAddForm = useTemplateRef('entityAddForm')
 
 const emit = defineEmits<{
   filtersChanged: []
-  locationChosen: [Coordinate]
+  locationChosen: [Coordinate, Extent?]
   entityChosen: [ViewerSearchedCachedEntity]
 }>()
 
@@ -516,7 +517,16 @@ function locationChosen(result: NominatimResult) {
     result.lon,
     result.lat,
   ]
-  emit('locationChosen', gpsCoordinates)
+  let extent: Extent | undefined
+  if (result.boundingbox) { // [min lat, min lon, max lat, max lon]
+    extent = [
+      result.boundingbox[2], // minx = min lon
+      result.boundingbox[0], // miny = min lat
+      result.boundingbox[3], // maxx = max lon
+      result.boundingbox[1], // maxy = max lat
+    ]
+  }
+  emit('locationChosen', gpsCoordinates, extent)
 }
 
 function entityChosen(result: ViewerSearchedCachedEntity) {

--- a/frontend/pages/map/[token].vue
+++ b/frontend/pages/map/[token].vue
@@ -5,7 +5,7 @@
       :show-map-button="false"
       :show-search-button="true"
       @filters-changed="refreshMap"
-      @location-chosen="goToGpsCoordinates"
+      @location-chosen="goToGpsLocation"
       @entity-chosen="goToEntity"
     />
     <div
@@ -70,6 +70,7 @@ import type { Coordinate } from 'ol/coordinate'
 import type { DisplayableCachedEntity, ViewerSearchedCachedEntity } from '~/lib'
 import state from '~/lib/viewer-state'
 import ViewerMap from '~/components/viewer/Map.vue'
+import type { Extent } from 'ol/extent'
 
 const toast = useToast()
 
@@ -180,6 +181,14 @@ function fitContainer() {
     return { height, top, position: 'absolute' }
   }
   return {} // Return default/fallback styles if needed
+}
+
+function goToGpsLocation(coordinates: Coordinate, extent?: Extent) {
+  return extent ? goToGpsExtent(extent) : goToGpsCoordinates(coordinates)
+}
+
+function goToGpsExtent(extent: Extent, maxZoom = 13) {
+  mapRef.value?.goToGpsExtent(extent, maxZoom)
 }
 
 function goToGpsCoordinates(coordinates: Coordinate, zoom = 13) {


### PR DESCRIPTION
Cette PR modifie le comportement de la carte quand un lieu géographique est sélectionné dans la recherche Nominatim.

Auparavant la carte était centrée sur la coordonnée renvoyée par le service, avec un zoom fixe.  
Avec cette PR la carte est centrée sur la zone renvoyée par le service (dont le centre n'est pas nécessairement le même que précédemment), avec un niveau de zoom adapté pour que la zone tienne à l'écran.

Cela signifie que le niveau de zoom sera différent pour une région (exemple : Ile de France) ou une ville (exemple : Arnay Le Duc).

Les informations de zone sont fournies par Nominatim (OpenStreetMap), et dépendent donc de ce que les mainteneureuses ont saisi là bas. En l'absence d'information l'ancien comportement est appliqué.

Fix #95