### PR TITLE
Correction de la construction de l'image docker suite aux workspaces npm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,8 +30,9 @@ Dockerfile
 /frontend/dist
 
 # Node dependencies
+/node_modules
 /frontend/node_modules
 
 # Generated from the backend openapi
-/frontend/lib/api.d.ts
+/frontend/app/lib/api.d.ts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ RUN cargo build --release;
 FROM node:24-alpine3.22 AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend .
-RUN npm ci && npm run build;
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci;
+WORKDIR /app/frontend
+RUN npm run build;
 
 # backend + frontend
 FROM alpine:3.22 AS safehaven


### PR DESCRIPTION
Cette PR est une tentative de correction de la construction de l'image docker qui ne fonctionne plus suite à l'emploi des workspaces npm.

Je n'ai pas pu tester le processus de build complet car mon espace disque est limité, mais cela a l'air d'aller jusqu'au build du backend et du frontend (l'installation des dépendances se passe bien).

Pour tester, construire une image avec `docker build -t safehaven .` .