### PR TITLE
Fix issue 117 filtrage non-refermable sur petits écrans

### DIFF
--- a/frontend/app/components/viewer/Navbar.vue
+++ b/frontend/app/components/viewer/Navbar.vue
@@ -224,6 +224,8 @@
   <Dialog
     v-model:visible="filterPopupVisible"
     header="Filtres"
+    :style="{ width: '50rem' }"
+    :breakpoints="{ '1199px': '75vw', '575px': '90vw' }"
     modal
   >
     <ViewerFilterConfig


### PR DESCRIPTION
Cette PR corrige le bug du filtrage sur le viewer qui dépasse de l'écran sur mobile quand on choisit plusieurs valeurs de contrainte avec des noms à rallonge.

Avant la PR :

- sur mobile, choisir de filtrer par contrainte "Prescription d'hormonothérapie" et cocher toutes les valeurs possibles, la boite de dialogue de filtrage dépasse de l'écran et devient non-fermable

Après la PR :

- faire de même, la boite de dialogue de filtrage ne dépasse plus et reste fermable

Fix #117