### PR TITLE
Fix issue 120 respect des contraintes dans l'affichage des enfants

### DIFF
--- a/backend/src/api/map.rs
+++ b/backend/src/api/map.rs
@@ -13,7 +13,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::fmt::Display;
 use tracing::debug;
@@ -434,6 +434,7 @@ pub struct FetchEntityRequest {
     pub active_categories: Vec<Uuid>,
     pub active_required_tags: Vec<Uuid>,
     pub active_hidden_tags: Vec<Uuid>,
+    pub enums_constraints: HashMap<String, Vec<Value>>,
 }
 
 #[utoipa::path(
@@ -483,6 +484,14 @@ async fn viewer_fetch_entity(
         .map_or(Ok(()), Err)?;
     debug!("[PERMDBG] No tag is explicitly excluded, continuing");
 
+    // The use of enum contraints must not be explicitly excluded
+    are_constraints_allowed(
+        &entity.family_id,
+        &token.fam_priv_idx,
+        &request.enums_constraints,
+    )?;
+    debug!("[PERMDBG] No enum constraint is explicitly excluded, continuing");
+
     let parents = PublicEntity::get_parents(id, &mut conn).await?;
     let children = PublicEntity::get_children(id, &mut conn).await?;
 
@@ -523,7 +532,7 @@ async fn viewer_fetch_entity(
         debug!("[PERMDBG] No tag are explicitly excluded, continuing");
     }
 
-    let filtered_children: Vec<PublicListedEntity> = authorized_children
+    let mut filtered_children: Vec<PublicListedEntity> = authorized_children
         .into_iter()
         // filter against request
         .filter(|child| {
@@ -539,9 +548,44 @@ async fn viewer_fetch_entity(
         })
         .collect();
     debug!(
-        "[PERMDBG] Found {} remaining children when applying user filters",
+        "[PERMDBG] Found {} remaining children when applying category and tag filters",
         filtered_children.len()
     );
+
+    let requires_children_data_filtering = !request.enums_constraints.is_empty();
+    if requires_children_data_filtering {
+        // gather children data to perform further filtering
+        let mut children_data: HashMap<Uuid, Value> = HashMap::new();
+        for child in &filtered_children {
+            children_data.insert(child.id, PublicEntity::get(child.id, &mut conn).await?.data);
+        }
+
+        // filter children again against request and children data
+        filtered_children.retain(|child| {
+            let default_json_map = Map::new();
+            let default_json_array = json!([]);
+            let child_data = children_data[&child.id]
+                .as_object()
+                .unwrap_or(&default_json_map);
+            request
+                .enums_constraints
+                .iter()
+                .all(|(enum_name, enum_values)| {
+                    let data = child_data.get(enum_name).unwrap_or(&default_json_array);
+                    if data.is_array() {
+                        // child data is an array, this is a EnumMultiOption
+                        let array = data.as_array().unwrap();
+                        return enum_values.iter().any(|value| array.contains(value));
+                    }
+                    // child data is not an array, this is a EnumSingleOption
+                    enum_values.contains(data)
+                })
+        });
+        debug!(
+            "[PERMDBG] Found {} remaining children when applying enum constraint filters",
+            filtered_children.len()
+        );
+    }
 
     // Parents must simply not be excluded to be shown, unlike children which must be allowed in their own right
     let filtered_parents: Vec<PublicListedEntity> = parents

--- a/frontend/app/lib/viewer-client.ts
+++ b/frontend/app/lib/viewer-client.ts
@@ -82,6 +82,7 @@ export default function useClient() {
       activeCategories: string[],
       activeRequiredTags: string[],
       activeHiddenTags: string[],
+      enumsConstraints: Record<string, Array<unknown>>,
     ): Promise<FetchedEntity> {
       const { data, error } = await rawClient.POST('/api/map/entities/{id}', {
         params: { path: { id } },
@@ -89,6 +90,7 @@ export default function useClient() {
           active_categories: activeCategories,
           active_required_tags: activeRequiredTags,
           active_hidden_tags: activeHiddenTags,
+          enums_constraints: enumsConstraints,
         },
       })
       if (error) throw error

--- a/frontend/app/lib/viewer-state.ts
+++ b/frontend/app/lib/viewer-state.ts
@@ -338,6 +338,7 @@ export class AppState {
       this.activeFilteringCategories,
       this.activeRequiredTags,
       this.activeHiddenTags,
+      this.activeFilteringEnums,
     )
   }
 
@@ -347,6 +348,7 @@ export class AppState {
       this.activeFilteringCategories,
       this.activeRequiredTags,
       this.activeHiddenTags,
+      this.activeFilteringEnums,
     )
   }
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3625,7 +3625,8 @@
         "required": [
           "active_categories",
           "active_required_tags",
-          "active_hidden_tags"
+          "active_hidden_tags",
+          "enums_constraints"
         ],
         "properties": {
           "active_categories": {
@@ -3647,6 +3648,13 @@
             "items": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          "enums_constraints": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {}
             }
           }
         }


### PR DESCRIPTION
Cette PR filtre l'affichage des enfants dans le viewer pour qu'il tienne compte des contraintes, en plus des catégories et des tags.

Attention, cette PR modifie les échanges API, il faut donc regénérer cette dernière (`regen_api` etc, voir le README).

Avant cette PR :
- Cocher le filtrage par contrainte "prescription d'hormonothérapie = oui, oui sous conditions"
- Cliquer sur une structure (ex : un CHU) contenant à la fois un-e prescripteurice de THS (ex : un-e endoc) et autre chose (ex : un CECOS)
- Constater que la liste des enfants propose à la fois les prescripteur-ices de THS mais aussi les autres (ce qui est un problème)

Après cette PR :
- Faire de même, seuls les enfants satisfaisant la contrainte de prescription d'hormonothérapie s'affichent dans la liste
- Tester aussi avec plusieurs contraintes en même temps

Fix #120 